### PR TITLE
Some cleaning on datastructure and alternative split/merge algo

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregatedReportsJdbcRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregatedReportsJdbcRepository.scala
@@ -30,7 +30,9 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
 *
 *************************************************************************************
-*/package com.normation.rudder.reports.aggregation
+*/
+
+package com.normation.rudder.reports.aggregation
 
 import net.liftweb.common.Loggable
 import org.joda.time.DateTime

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationConstants.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationConstants.scala
@@ -21,5 +21,21 @@ object AggregationConstants {
   val DATETIME_FORMAT = "yyyy-MM-dd"
   val DATETIME_PARSER = DateTimeFormat.forPattern(DATETIME_FORMAT)
 
+  /**
+   * The expected time between two execution of the agent on a given machine.
+   * It's just expected, as a user can clearly start cf-agent at any time, and
+   * two runs may have more than that intervalle between run (pathological 
+   * example: if a run takes more than RUN_INTERVALL to finished, then the time
+   * between that one and the precedent is more than RUN_INTERVALL).
+   * 
+   * Time is in seconds
+   */
+  val RUN_INTERVAL : Int = 5*60
+  
+  /**
+   * Duration is in seconds
+   */
+  val AGGREGATION_INTERVAL : Int = RUN_INTERVAL + RUN_INTERVAL / 2
+  
   implicit def toTimeStamp(d:DateTime) : Timestamp = new Timestamp(d.getMillis)
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationConstants.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationConstants.scala
@@ -5,6 +5,7 @@ import com.normation.rudder.domain.reports.bean.Reports._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.DateTime
 import java.sql.Timestamp
+import org.joda.time.Interval
 
 object AggregationConstants {
 
@@ -24,18 +25,39 @@ object AggregationConstants {
   /**
    * The expected time between two execution of the agent on a given machine.
    * It's just expected, as a user can clearly start cf-agent at any time, and
-   * two runs may have more than that intervalle between run (pathological 
+   * two runs may have more than that intervalle between run (pathological
    * example: if a run takes more than RUN_INTERVALL to finished, then the time
    * between that one and the precedent is more than RUN_INTERVALL).
-   * 
+   *
    * Time is in seconds
    */
   val RUN_INTERVAL : Int = 5*60
-  
+
   /**
    * Duration is in seconds
    */
   val AGGREGATION_INTERVAL : Int = RUN_INTERVAL + RUN_INTERVAL / 2
-  
+
+  /**
+   * minimum time under which to date are "equals"
+   * that allows to not take into accounts glipse that may
+   * happens time difficulties
+   * moreover, we really don't expect two agent run to be
+   * nearer than that time
+   *
+   * Unit: seconds
+   */
+  val RESOLUTION = 10
+
+  /**
+   * Define if two date coincides
+   */
+  def coincide(t1: DateTime, t2: DateTime) : Boolean = {
+    (new Interval(
+        t1.minusSeconds(RESOLUTION)
+      , t1.plusSeconds(RESOLUTION))
+    ).contains(t2)
+  }
+
   implicit def toTimeStamp(d:DateTime) : Timestamp = new Timestamp(d.getMillis)
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationService.scala
@@ -186,42 +186,6 @@ class AggregationService(
     }
 
   }
-/*
-  def getTimeInterval() : Option[Interval] = {
-
-    val intervalStartDateTime = (updatesEntriesRepository.getAgregationUpdateTime) getOrElse {
-      val expectedReports = expectedReportRepository.findExpectedReports(new DateTime(0), DateTime.now())
-      //val oldestReportDate = reportsRepository.getOldestReports.getOrElse(None).map(_.executionDate).getOrElse(DateTime.now())
-      expectedReports match {
-        case Full(seq) => seq.sortWith((x,y)=> x.beginDate.isBefore(y.beginDate)).headOption.map(_.beginDate).getOrElse(DateTime.now)
-        case _ => DateTime.now
-      }
-    }
-    val reportLimit = DateTime.now.minusHours(reportDelay)
-    val maxReportDate = intervalStartDateTime.plusDays(maxDays)
-
-    if (intervalStartDateTime.isAfter(reportLimit))
-      None
-    else {
-      val end = if (reportLimit.isAfter(maxReportDate)) maxReportDate else reportLimit
-      Some(new Interval(intervalStartDateTime,end))
-    }
-  }
-
-    , @Column("directiveid") directiveId: String
-  , @Column("ruleid") ruleId: String
-  , @Column("beginserial") beginSerial: Int
-  , @Column("endserial") endSerial: Int
-  , @Column("component") component: String
-  , @Column("keyvalue") keyValue: String
-  , state: DBReportType
-  , @Column("message") message: String
-  , @Column("startDate") startDate: Timestamp
-  , @Column("endDate") endDate: Timestamp // only the endDate is mutable
-  , @Column("received") received : Int
-  , @Column("expected") expected : Int
-*/
-
 }
 
 class InitializeAggregatedReport {

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/AggregationService.scala
@@ -54,6 +54,8 @@ import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.domain.reports.bean.ReportType._
 import com.normation.rudder.domain.reports.RuleExpectedReports
 
+import com.normation.rudder.reports.aggregation.AggregationConstants.AGGREGATION_INTERVAL
+
 /**
  * That service contains most of the logic to merge
  * interval of same criticity together.
@@ -76,15 +78,14 @@ class AggregationService(
 //  }
 
 
-  val reportInterval : Int = 5
 
   def createAggregatedReportsFromReports (reports : Seq[Reports],expectedReports : Seq[LinearisedExpectedReport]  ) = {
     reports.groupBy(_.executionTimestamp).flatMap{
       case (executionTimeStamp,reports) =>
         val headReport = reports.head
         val (expected, unexpected) =  reports.partition(report => expectedReports.exists(_.serial == report.serial))
-        val expectedAggregated = expected.map(report => AggregatedReport( report, ReportType(report), 1, 1))
-        val unexpectedAggregated = unexpected.map(report => AggregatedReport(report, UnknownReportType, 1 , 1))
+        val expectedAggregated = expected.map(report => AggregatedReport( report, ReportType(report), 1))
+        val unexpectedAggregated = unexpected.map(report => AggregatedReport(report, UnknownReportType, 1))
 
         unexpectedAggregated ++ expectedAggregated
     }.toSeq
@@ -103,15 +104,15 @@ class AggregationService(
           case Full(expectedReports) =>
             val linearisedExpectedReports = expectedReports.flatMap(lineariseExpectedReport(_)).distinct
             //linearisedExpectedReports.foreach(//logger.warn(_))
-            val expectedMap = linearisedExpectedReports.groupBy(ReportKey(_))
-            reportsByRule.groupBy(ReportKey(_)).map {
+            val expectedMap = linearisedExpectedReports.groupBy( _.key )
+            reportsByRule.groupBy( ReportKey(_) ).map {
               case (key,reports) =>
                 //logger.info(s"found ${reports.size} for reportKey ${key}")
                 expectedMap.get(key) match {
                   // There is no expected report => Map to UnexpectedReport
                   case None =>
                     //logger.info(s"no expected for reportKey ${key}")
-                    (reports.groupBy(_.executionTimestamp).map{ case (_,reports) => AggregatedReport(reports.head,UnknownReportType,reports.size,reports.size)}.toSeq, Seq())
+                    (reports.groupBy(_.executionTimestamp).map{ case (_,reports) => AggregatedReport(reports.head,UnknownReportType,reports.size)}.toSeq, Seq())
                   case Some(expectedReports) =>
 
                     //logger.info(s"found ${expectedReports.size} expected for reportKey ${key}")
@@ -119,20 +120,13 @@ class AggregationService(
                     //assert(false)
                     val linearisedAggregated = expectedMap.get(key).getOrElse(Seq()).map{base =>
                       AggregatedReport (
-                          base.nodeId
-                        , base.ruleId
-                        , base.serial
-                        , base.serial
-                        , base.directiveId
-                        , base.component
-                        , base.keyValue
+                          base.key
+                        , 0
                         , SuccessReportType
+                        , new Interval(base.startDate, base.endDate)
                         , ""
-                        , base.startDate
-                        , base.endDate
-                        , 0
-                        , base.cardinality
-                        , 0
+                        , SerialInterval(base.serial, base.serial)
+                        , None
                     ) }
                     logger.info (s"Merge One started, expected : ${linearisedAggregated.size}, ${ReportsToAdd.size}")
                     val merged = mergeAggregatedReports(linearisedAggregated, ReportsToAdd)
@@ -256,7 +250,11 @@ class AggregationService(
       reportToMerge <- reportsToMerge
 
     } yield {
-      val updatedReport = baseSeq.filter(baseReport => (baseReport.endDate isBefore reportToMerge.startDate) && (baseReport.endDate isAfter (reportToMerge.startDate minusMinutes reportInterval*2))) match {
+      val updatedReport = 
+        baseSeq.filter(baseReport => 
+             (baseReport.interval.getEnd isBefore reportToMerge.interval.getStart) 
+          && (baseReport.interval.getEnd isAfter (reportToMerge.interval.getStart minusMinutes AGGREGATION_INTERVAL))
+        ) match {
         case mergeReports if !mergeReports.isEmpty =>
         //logger.warn("beforeMerge")
         beforeMerge match {
@@ -266,7 +264,7 @@ class AggregationService(
               //logger.error(reportToMerge)
               //logger.info(beforeReport)
               reportsToSave ++= mergeReports.map{report => unchanged -= report
-              report.copy(endDate = reportToMerge.startDate)}
+              report.copy(interval = new Interval(report.interval.getStart, reportToMerge.interval.getStart))}
               reportsToDelete += beforeReport
             } else {
               // Nothing to save
@@ -274,10 +272,10 @@ class AggregationService(
             case None =>
               // Nothing to save
         }
-        mergeReports.find (mergeReport => mergeReport.state == reportToMerge.state && mergeReport.received == reportToMerge.received ) match {
+        mergeReports.find (mergeReport => mergeReport.status == reportToMerge.status && mergeReport.received == reportToMerge.received ) match {
             case Some(mergeReport) =>
               //logger.info("secondPart")
-              val reportMerged =  mergeReport.copy(endDate = reportToMerge.endDate)
+              val reportMerged =  mergeReport.copy(interval = new Interval(mergeReport.interval.getStart, reportToMerge.interval.getEnd))
               if (reportsToSave.contains(mergeReport)) {
                 reportsToSave.update(reportsToSave.indexOf(mergeReport), reportMerged)
               } else {
@@ -296,7 +294,7 @@ class AggregationService(
       }
 
       //logger.info("test")
-      baseSeq.filter(baseReport => (baseReport.startDate isBefore (updatedReport.endDate plusMinutes reportInterval*2))&& (baseReport.startDate after reportToMerge.endDate) ) match {
+      baseSeq.filter(baseReport => (baseReport.interval.getStart isBefore (updatedReport.interval.getEnd plusMinutes AGGREGATION_INTERVAL))&& (baseReport.interval.getStart after reportToMerge.interval.getEnd) ) match {
         case mergeReports  =>
         val updatedReportAgain = afterMerge match {
           case Some(afterReport) =>
@@ -306,7 +304,7 @@ class AggregationService(
             //logger.info(mergeReports.size.toString)
             if (!mergeReports.isEmpty) {
               if (afterReport.received == 0) {
-                val updatedReportAgain = updatedReport.copy(endDate = afterReport.endDate)
+                val updatedReportAgain = updatedReport.copy(interval = new Interval(updatedReport.interval.getStart, afterReport.interval.getEnd))
                 if (reportsToSave.contains(updatedReport)) {
                   reportsToSave.update(reportsToSave.indexOf(updatedReport), updatedReportAgain)
                 } else {
@@ -325,10 +323,10 @@ class AggregationService(
             updatedReport
         }
         //logger.warn(s"after ended, second part $updatedReportAgain")
-        mergeReports.find (mergeReport => mergeReport.state == updatedReportAgain.state && mergeReport.received == updatedReportAgain.received ) match {
+        mergeReports.find (mergeReport => mergeReport.status == updatedReportAgain.status && mergeReport.received == updatedReportAgain.received ) match {
             case Some(mergeReport) =>
               unchanged -= mergeReport
-              val reportMerged =  updatedReportAgain.copy(endDate = mergeReport.endDate)
+              val reportMerged =  updatedReportAgain.copy(interval = new Interval(updatedReportAgain.interval.getStart, mergeReport.interval.getEnd))
               if (reportsToSave.contains(updatedReportAgain)) {
                 reportsToSave.update(reportsToSave.indexOf(updatedReportAgain), reportMerged)
               } else {
@@ -356,27 +354,27 @@ class AggregationService(
   def splitConflict (conflicting : AggregatedReport, report : AggregatedReport) : (Option[AggregatedReport],Seq[AggregatedReport],Option[AggregatedReport]) = {
 
     def splitBegin (base: AggregatedReport, newReportBegin: DateTime) = {
-      val splittedEnd =  base.copy(startDate = newReportBegin, id = 0)
-      val splittedBegin = base.copy(endDate = newReportBegin)
+      val splittedEnd =  base.copy(interval = new Interval(newReportBegin, base.interval.getEnd) , storageId = None)
+      val splittedBegin = base.copy(interval = new Interval(base.interval.getStart, newReportBegin))
       (splittedBegin,splittedEnd)
     }
 
     def splitEnd (base: AggregatedReport, newReportEnd: DateTime) = {
-      val splittedBegin =  base.copy(endDate = newReportEnd)
-      val splittedEnd = base.copy(startDate = newReportEnd, id = 0)
+      val splittedBegin =  base.copy(interval = new Interval(base.interval.getStart, newReportEnd))
+      val splittedEnd = base.copy(interval = new Interval(newReportEnd, base.interval.getEnd), storageId = None)
       (splittedBegin,splittedEnd)
     }
 
-    val (notConflictingBegin, conflictingEnd) = if ((conflicting.startDate isBefore report.startDate)) {
-      val (notConflictingBegin, conflictingEnd) = splitBegin(conflicting,report.startDate)
+    val (notConflictingBegin, conflictingEnd) = if ((conflicting.interval.getStart isBefore report.interval.getStart)) {
+      val (notConflictingBegin, conflictingEnd) = splitBegin(conflicting,report.interval.getStart)
 
       (Some(notConflictingBegin), conflictingEnd)
     } else {
       (None,conflicting)
     }
 
-    val (notConflictingEnd, conflictingPart) = if ((conflictingEnd.endDate isAfter report.endDate)) {
-      val ( conflictingPart, notConflictingEnd) = splitEnd(conflictingEnd,report.endDate)
+    val (notConflictingEnd, conflictingPart) = if ((conflictingEnd.interval.getEnd isAfter report.interval.getEnd)) {
+      val ( conflictingPart, notConflictingEnd) = splitEnd(conflictingEnd,report.interval.getEnd)
 
       (Some(notConflictingEnd), conflictingPart)
     } else {
@@ -386,19 +384,19 @@ class AggregationService(
 
     // Check if there is to much Report
     val newCount = report.received + conflictingPart.received
-    val resolvedConflicts = if (newCount > report.expected) {
+    val resolvedConflicts = if (newCount > 1) { //we can have at most one report for a key
       // TOO MUCH PUT UNKNOWN WITH NEWCOUNT RECEIVED
-      Seq(conflicting.copy(state = UnknownReportType, received = newCount, expected = newCount))
+      Seq(conflicting.copy(status = UnknownReportType, received = newCount))
     } else {
       // Check if same state
-      if (report.state == conflictingPart.state) {
+      if (report.status == conflictingPart.status) {
         // Update receive Number and return
         Seq(conflictingPart.copy(received = newCount, message = report.message))
       } else {
         // check if both are empty (should not Happen empty reports whoudl already been treated because they should all get Success status (with 0 reports)
         if (newCount == 0){
           // Both empty report, Wrong report type here, repair it
-          Seq(conflicting.copy(state = SuccessReportType))
+          Seq(conflicting.copy(status = SuccessReportType))
         } else {
           // Still need to remove empty if there exists, There will still be at least one report in it
           Seq(conflictingPart,report).filter(_.received == 0)
@@ -411,37 +409,37 @@ class AggregationService(
 
   def mergeOneAggregatedReport ( base : Seq[AggregatedReport], report : AggregatedReport ) : (Seq[AggregatedReport],Seq[AggregatedReport],Seq[AggregatedReport]) = {
     def createEmptyReport (base: AggregatedReport, begin : DateTime, end: DateTime) = {
-      base.copy(startDate = begin, endDate = end)
+      base.copy(interval = new Interval(begin, end))
     }
 
   logger.warn (s"merge $report in ${base.size}")
     if (!base.isEmpty) {
     // Is the report after all aggregated reports
-    if (base.forall(_.endDate isBefore report.startDate) ) {
+    if (base.forall(_.interval.getEnd isBefore report.interval.getStart) ) {
       // Get last report from this list
-      val maxEndDate : AggregatedReport = base.maxBy(_.endDate.getMillis())
+      val maxEndDate : AggregatedReport = base.maxBy(_.interval.getEnd.getMillis())
       val probablyUnchanged = base.filterNot(_ == maxEndDate)
       val (reportsToSave,unchanged) =
-        if ((maxEndDate.endDate isBefore report.startDate) &&(maxEndDate.endDate isAfter (report.startDate minusMinutes (2 * reportInterval)))) {
+        if ((maxEndDate.interval.getEnd isBefore report.interval.getStart) &&(maxEndDate.interval.getEnd isAfter (report.interval.getStart minusMinutes (AGGREGATION_INTERVAL)))) {
         // Check if same report has been received
           logger.info("merge after")
-          if (maxEndDate.state == report.state && maxEndDate.received == report.received) {
+          if (maxEndDate.status == report.status && maxEndDate.received == report.received) {
           // Extend actual report
             //logger.info("extend")
-            (Seq(maxEndDate.copy(endDate = report.endDate)),probablyUnchanged)
+            (Seq(maxEndDate.copy(interval = new Interval(maxEndDate.interval.getStart, report.interval.getEnd))),probablyUnchanged)
           } else {
             // Check if this a no answer
             if (report.received == 0) {
               // Nothing to do, waiting for a new report
-              (Seq(report.copy(startDate = maxEndDate.endDate)),base)
+              (Seq(report.copy(interval = new Interval(maxEndDate.interval.getEnd, report.interval.getEnd))),base)
             } else {
               // extend previous to beginning of new report and and this new report
 
-              (Seq(maxEndDate.copy(endDate = report.startDate),report),probablyUnchanged)
+              (Seq(maxEndDate.copy(interval = new Interval(maxEndDate.interval.getStart, report.interval.getStart)),report),probablyUnchanged)
             }
           }
         } else {
-          (Seq(createEmptyReport(report, maxEndDate.endDate, report.startDate), report), base)
+          (Seq(createEmptyReport(report, maxEndDate.interval.getEnd, report.interval.getStart), report), base)
         }
       (reportsToSave,Seq(), unchanged)
     } else {
@@ -477,8 +475,8 @@ class AggregationService(
   }
 
   def mergeAggregatedReports ( base : Seq[AggregatedReport], toMerge : Seq[AggregatedReport])  : (Seq[AggregatedReport], Seq[AggregatedReport])= {
-    val baseMap = base.groupBy(ReportKey(_)).mapValues(_.sortBy(_.startDate.getMillis()))
-    val mergeMap = toMerge.groupBy(ReportKey(_)).mapValues(_.sortBy(_.startDate.getMillis()))
+    val baseMap = base.groupBy( _.key ).mapValues(_.sortBy(_.interval.getStart.getMillis()))
+    val mergeMap = toMerge.groupBy( _.key ).mapValues(_.sortBy(_.interval.getStart.getMillis()))
     val mergingMap = (for {
       key <- (baseMap.keys ++ mergeMap.keys).toSeq.distinct
     } yield {
@@ -526,13 +524,15 @@ class AggregationService(
        value <-component.componentsValues
     } yield {
       LinearisedExpectedReport(
-          nodeId
-        , directive.directiveId
-        , aRuleExpectedReports.ruleId
+          ReportKey(
+              nodeId
+            , aRuleExpectedReports.ruleId
+            , directive.directiveId
+            , component.componentName
+            , value
+          )
         , aRuleExpectedReports.serial
-        , component.componentName
         , component.cardinality
-        , value
         , aRuleExpectedReports.beginDate
         , aRuleExpectedReports.endDate.getOrElse(DateTime.now)
       )
@@ -543,12 +543,8 @@ class AggregationService(
 //case class MissingReports (expected : Int, received : Int) => Sérialisé en _received_expected pour stocker le nombre
 
 case class LinearisedNodeStatusReport(
-    nodeId       : NodeId
-  , ruleId       : RuleId
+    key          : ReportKey
   , serial       : Int
-  , directiveId  : DirectiveId
-  , component    : String
-  , keyValue     : String
   , reportType   : ReportType
   , message      : String
   , executionDate: DateTime
@@ -563,15 +559,18 @@ object LinearisedNodeStatusReport {
       keyValue  <- component.componentValues ++ component.unexpectedCptValues
     } yield {
       LinearisedNodeStatusReport(
-          nodeStatusReport.nodeId
-        , nodeStatusReport.ruleId
+          ReportKey(
+              nodeStatusReport.nodeId
+            , nodeStatusReport.ruleId
+            , directive.directiveId
+            , component.component
+            , keyValue.componentValue
+          )
         , serial
-        , directive.directiveId
-        , component.component
-        , keyValue.componentValue
         , keyValue.cptValueReportType
         , keyValue.message.mkString(";")
-        , execDate)
+        , execDate
+      )
     }
   }
 
@@ -581,39 +580,11 @@ object LinearisedNodeStatusReport {
 
 
 // a class not unlike the AggregatedReports
+//TODO: what is its goal ?
 case class LinearisedExpectedReport(
-    nodeId       : NodeId
-  , directiveId  : DirectiveId
-  , ruleId       : RuleId
-  , serial       : Int
-  , component    : String
-  , cardinality  : Int
-  , keyValue     : String
-  , startDate    : DateTime
-  , endDate      : DateTime
+    key         : ReportKey
+  , serial      : Int
+  , cardinality : Int
+  , startDate   : DateTime
+  , endDate     : DateTime
 ) extends HashcodeCaching
-
-// this class that identify the entry
-case class ReportKey(
-       ruleId      : RuleId
-    ,  directiveId : DirectiveId
-    ,  component   : String
-    ,  keyValue    : String
-    ,  nodeId      : NodeId
-) extends HashcodeCaching
-
-object ReportKey {
-  def apply(entry : LinearisedExpectedReport) : ReportKey =
-    ReportKey(entry.ruleId, entry.directiveId, entry.component, entry.keyValue, entry.nodeId)
-
-  def apply(entry : LinearisedNodeStatusReport) : ReportKey =
-    ReportKey(entry.ruleId, entry.directiveId, entry.component, entry.keyValue, entry.nodeId)
-
-  def apply(entry : Reports) : ReportKey =
-    ReportKey(entry.ruleId, entry.directiveId, entry.component, entry.keyValue, entry.nodeId)
-
-  def apply(entry : AggregatedReport) : ReportKey =
-    ReportKey(
-        entry.ruleId,entry.directiveId,entry.component, entry.keyValue, entry.nodeId)
-
-}

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/UnitAggregationService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/aggregation/UnitAggregationService.scala
@@ -1,0 +1,395 @@
+/*
+*************************************************************************************
+* Copyright 2013 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.reports.aggregation
+
+import scala.collection.SortedMap
+import scala.collection.SortedSet
+import org.joda.time.DateTime
+import org.joda.time.Interval
+import com.normation.rudder.reports.aggregation.AggregationConstants._
+import scala.collection.Iterator
+import com.normation.rudder.domain.reports.bean.ReportType
+import com.normation.rudder.batch.AggregateReports
+import net.liftweb.common.Loggable
+import com.normation.rudder.domain.reports.bean.Reports
+import com.normation.rudder.domain.reports.RuleExpectedReports
+import net.liftweb.common.Box
+import com.normation.rudder.domain.reports.bean.UnknownReportType
+
+/**
+ * Representation of the moment when an agent ran
+ */
+final case class AgentExecution(timestamp: DateTime)
+
+/**
+ * Agent report, with only the interesting parts for us
+ */
+final case class RunReport(timestamp: DateTime, status: ReportType, serial: Int)
+
+
+/**
+ * A class that only hold interesting parts of aggregated
+ * report for unit aggregation:
+ * - not the key
+ * - only interval and optional existing db key
+ */
+final case class AR(
+    interval : Interval
+  , status   : ReportType
+  , storageId: Option[Long]
+) {
+
+  val startPoint = ARStart(interval.getStart, status, storageId)
+  val endGap = Gap(interval.getEnd)
+}
+
+/**
+ * The list of each execution, plus utility method to give
+ * the corresponding interval
+ *
+ * Value must be sorted
+ *
+ * An execution sequence can't be empty
+ * (at least, we do know that reports execution time are in it)
+ */
+final case class ExecutionSequence private (instants: SortedSet[DateTime]) {
+
+  if(instants.isEmpty) throw new IllegalArgumentException("An execution sequence can not be empty")
+
+  val intervals: Seq[Interval] = instants.toSeq.sliding(2).map { s =>
+          //we are building the intrvalle for the first, the second is the
+          //end edge
+          val start = s(0)
+          val end = if(s.size == 2) s(1) else s(0)
+
+          //take care of the case where the next known run is
+          //too far away, for example because the node was down
+          //for a period of time
+          val maxEnd = start.plusSeconds(AGGREGATION_INTERVAL)
+          val normalizedEnd = if(end.isAfter(maxEnd)) maxEnd else end
+
+          new Interval(start, normalizedEnd)
+  }.toSeq
+
+}
+
+object ExecutionSequence {
+  implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
+
+  def apply(seq: Iterable[DateTime]): ExecutionSequence = ExecutionSequence(SortedSet[DateTime]() ++ seq)
+}
+
+
+/**
+ * That class represent the starting point of
+ * an aggregating report of the given type.
+ */
+sealed trait StartingTime {
+  val start: DateTime
+  def withStart(t: DateTime) : StartingTime
+}
+final case class Gap(start: DateTime) extends StartingTime {
+  override def withStart(t: DateTime) = Gap(t)
+}
+final case class ARStart(
+    start    : DateTime
+  , status   : ReportType
+  , storageId: Option[Long]
+) extends StartingTime {
+  override def withStart(t: DateTime) = this.copy(start = t)
+}
+
+/**
+ * Main data structure representing aggregated reports
+ * between to dates.
+ *
+ * Aggregated reports don't overlaps, but they may not
+ * be continuous (Gap can be present, especially at the
+ * end).
+ */
+case class AggregatedReports private ( intervalStarts: SortedSet[StartingTime] ) {
+  import AggregatedReports._
+
+  /**
+   * Does a startingtime exists for that datetime ?
+   */
+  def isDefinedAt(t: DateTime) : Boolean = {
+    intervalStarts.map( _.start ).contains(t)
+  }
+
+  /**
+   * Get the starting point that contains
+   * the given time.
+   * If a starting point as the same date, it's
+   * that one that is returned.
+   * If t if before the first starting point,
+   * a new Gap is created starting at that point.
+   */
+  def getPreviousStartingPoint(t: DateTime) : StartingTime = {
+
+    ((Gap(t):StartingTime)/:intervalStarts)( (previous, current) =>
+      if(current.start.isAfter(t)) previous
+      else current
+    )
+  }
+
+  /**
+   * Add or replace the starting point with the same datetime
+   */
+  def replace(point: StartingTime) : AggregatedReports = {
+    new AggregatedReports(intervalStarts.filterNot( _.start == point.start) + point)
+  }
+
+  /**
+   * Check that all interval endpoints coincide with the know exec seq.
+   * For the one that coincide but are not equals, make the equals.
+   * For the one that does not coincide
+   * TODO: what to do ? For now, find the nearest exec time, and take that;
+   * Certainly a lot of things to validate:
+   * - what happen to "near" reports (check consistency after/before)
+   * - ...
+   */
+  def normalizeWith(execSeq: ExecutionSequence) : AggregatedReports = {
+    val normalized = intervalStarts.map { t =>
+      if(execSeq.instants.contains(t.start)) t
+      else execSeq.instants.find(i => coincide(t.start, i)) match {
+        case Some(i) => t.withStart(i)
+        case None =>
+          val i = (execSeq.instants.toSeq
+            .map(i => (i, Math.abs(t.start.getMillis - i.getMillis) ))
+            .sortBy( _._2 )
+            .head._1
+          )
+          t.withStart(i)
+      }
+    }
+
+    new AggregatedReports(normalized)
+  }
+}
+
+object AggregatedReports extends Loggable {
+  implicit def startingTimeOrdering: Ordering[StartingTime] = Ordering.fromLessThan(_.start isBefore _.start)
+
+  def apply(reports: Seq[AR]) : AggregatedReports = {
+
+    val sorted = reports.sortWith( (t1,t2) => t1.interval.getStart.isBefore( t2.interval.getStart) )
+
+    val seq = sorted.sliding(2).flatMap{ s =>
+
+      if(s.size == 1) { //last report: if interval length < RESOLUTION, only one datepoint.
+        if(s(0).interval.toDurationMillis < RESOLUTION) {
+          Seq(s(0).startPoint)
+        } else {
+          Seq(s(0).startPoint, s(0).endGap)
+        }
+      } else {
+        val p1 = s(0)
+        val p2 = s(1)
+
+        if(coincide(p1.interval.getEnd, p2.interval.getStart)) {
+          // OK, the end of p1 coincide with the start of p2
+          Seq(p1.startPoint)
+        } else if(p1.interval.getEnd.isAfter(p2.interval.getStart)) {
+          //that's an error?
+          //perhaps a precedent hypothesis on the duration of the interval
+          //that was corrected afterward by the reception of the log.
+          //In all case, log the problem, and explain that since now,
+          //we will take p2.start as end to p1.
+          logger.error("Error on aggregated reports: found an interval that ends after the start of another run.") //TODO: better reporting
+          Seq(p1.startPoint)
+        } else {
+          //if p1 is 0-lenght intervalle, extend it
+          if(coincide(p1.interval.getStart, p1.interval.getEnd)) {
+            //extend how mych ?
+            if( p1.interval.getEnd.plusSeconds(AGGREGATION_INTERVAL).isAfter(p2.interval.getStart) ) {
+              Seq(p1.startPoint)
+            } else { //extends by one run, but expects strange things in the future
+              Seq(p1.startPoint, Gap(p1.interval.getStart.plusSeconds(RUN_INTERVAL)))
+            }
+          } else {
+            //case for a gap in our aggregated reports
+            Seq(s(0).startPoint, s(0).endGap)
+          }
+        }
+      }
+    }.toSeq
+
+    AggregatedReports(SortedSet() ++ seq)
+  }
+}
+
+/**
+ * That class holds the logic to aggregate reports for a
+ * given report key.
+ * It rely on other services to:
+ * - get the datas
+ * - sort them by key
+ *
+ * The global logic of the algo is;
+ *
+ * 1/ Build the sequence of execution interval
+ *    from agent runs
+ *    - take care of 3 cases:
+ *      - run with a next run < AGGREGATION_INTERVAL
+ *      - run with a next run > AGGREGATION_INTERVAL
+ *      - run without a next run
+ *
+ * 2/ Normalize existing aggregated reports
+ *    on the execution sequence:
+ *    - extends 0-lenght interval to match execution
+ *      intervals one
+ *    - check that edges of existing aggregated report
+ *      are aligned with edges of execution sequence
+ *
+ * 3/ From expected reports, execution reports and
+ *    execution sequence, build new aggregated
+ *    reports
+ *
+ * 4/ split existing aggregated report according to
+ *    new aggregated reports
+ *
+ * 5/ merge overlapping interval
+ *
+ * 6/ merge contiguous interval with compatible status
+ *
+ */
+class UnitAggregationService {
+
+  /**
+   * Build the sequence of execution interval
+   * from agent runs
+   *    - take care of 3 cases:
+   *      - run with a next run < AGGREGATION_INTERVAL
+   *      - run with a next run > AGGREGATION_INTERVAL
+   *      - run without a next run
+   *
+   * Hypothesis on the returned datas:
+   * all execution reports timestamp matches an edge
+   * of the execution sequence by construction of the
+   * execution sequence.
+   *
+   */
+  def buildExecutionSequence(agentExecutions: Set[AgentExecution]): ExecutionSequence = {
+    ExecutionSequence(agentExecutions.map(_.timestamp))
+  }
+
+  /**
+   * That class align existing aggregated report to
+   *
+   * The return value is correctly sorted by time, without
+   * any overlapping intervals.
+   */
+  def normalizeExistingAggregatedReport(reports: Set[AR], execSeq: ExecutionSequence): AggregatedReports = {
+    val aggregatedReports = AggregatedReports(reports.toSeq)
+    aggregatedReports.normalizeWith(execSeq)
+  }
+
+  /**
+   * Build new expected reports.
+   * They are normalized (and aligned) with execSeq by construction.
+   *
+   * Hypothesis:
+   * - expected reports are sorted by beginDate asc
+   * - both expected reports and execSeq endpoints are over each runReport timestamp
+   *   (i.e: we actually got all the date we needed to work)
+   */
+  def createNewAggregatedReports(runReports: Seq[RunReport], expectedReports: Seq[RuleExpectedReports], execSeq: ExecutionSequence) : Seq[AR] = {
+
+    def createOne(report: RunReport) : AR = {
+      //find the corresponding expected report
+      val status = for {
+        //no expected means that the report was not exepected :)
+        expected <- expectedReports.takeWhile(expect => report.timestamp.isBefore(expect.beginDate)).lastOption
+        serialOk <- if(expected.serial == report.serial) Some(report.status) else None
+      } yield {
+        serialOk
+      }
+
+      //now, find the interval for that report
+
+      val interval = execSeq.intervals.find( i => i.contains(report.timestamp) ) match {
+        case None =>
+          //something failed miserly here. It seems that our execSeq miss some datapoint.
+          if(report.timestamp.isBefore(execSeq.instants.head) || report.timestamp.isAfter(execSeq.instants.last)) {
+            throw new IllegalArgumentException("Got a report out of execution sequence bounds: " + report)
+          } else {
+            //exec sequence misses some datapoints
+            val end = report.timestamp.plusSeconds(RUN_INTERVAL)
+            execSeq.intervals.find( j => j.contains(end)) match {
+              case None => new Interval(report.timestamp, end)
+              case Some(x) => new Interval(report.timestamp, x.getStart)
+            }
+          }
+        case Some(i) => i
+      }
+
+      AR(
+          interval
+        , status.getOrElse(UnknownReportType)
+        , None
+      )
+    }
+
+    runReports.map(createOne(_))
+  }
+
+
+  /**
+   * That method add new startpoint where needed in existing reports
+   */
+  def splitExisting(aggregatedReports: AggregatedReports, newReports: Seq[AR]): AggregatedReports = {
+    (aggregatedReports/:newReports.flatMap(r => Seq(r.startPoint.start, r.endGap.start))){ case (agg, instant) =>
+      if(agg.isDefinedAt(instant)) agg
+      else {
+        val newPoint = agg.getPreviousStartingPoint(instant) match {
+          case Gap(_) => Gap(instant)
+          case ARStart(start, status, _) => ARStart(instant, status, None)
+        }
+        agg.replace(newPoint)
+      }
+    }
+  }
+
+  /**
+   * Merge new aggregated report with existing one.
+   * Hypothesis: a splitExisting was done, so that each aggregated report has
+   * exactly both its start point and its end point defined as a point of
+   * the aggregated reoport.
+   */
+  def mergeUpdateStatus() = ???
+
+}
+

--- a/rudder-core/src/test/scala/com/normation/rudder/reports/aggregation/AggregationTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/reports/aggregation/AggregationTest.scala
@@ -24,6 +24,9 @@ class AggregationTest extends Specification {
   private implicit def str2nodeId(s:String) = NodeId(s)
   private implicit def tuple2ToInterval(t2: Tuple2[DateTime, DateTime]) : Interval = new Interval(t2._1, t2._2)
 
+  val aggregation = new SplitMergeAggregatedReport()
+  val initialization = new InitializeAggregatedReport()
+  
   val now = DateTime.now()
 
   val report: Reports  = ResultSuccessReport(now, "cr", "policy", "one", 12, "component", "value",now, "message")
@@ -82,7 +85,6 @@ class AggregationTest extends Specification {
     , Some(42)
   )
 
-  val dummyAgregation = new AggregationService(null, null, null, null, null,0,0)
 
   val ending : AggregatedReport = AggregatedReport (
       key
@@ -97,7 +99,7 @@ class AggregationTest extends Specification {
 
   "Aggregation" should {
 
-    val (begin,reports,end) = dummyAgregation.splitConflict(baseReport, reportToAdd)
+    val (begin,reports,end) = aggregation.splitConflict(baseReport, reportToAdd)
     "have a beginning" in {
 
       begin === Some(begining)
@@ -114,13 +116,13 @@ class AggregationTest extends Specification {
   }
 
   "Reports" should {
-    val result = dummyAgregation.createAggregatedReportsFromReports(Seq(report), Seq(expectedReport))
+    val result = initialization.fromExecutionReports(Seq(report), Seq(expectedReport))
     result.head === reportToAdd
   }
 
   "Merge" should {
-    val (toSave,toDelete) = dummyAgregation.mergeAggregatedReports(Seq(baseReport), Seq(reportToAdd))
-    val (toSave2,toDelete2) = dummyAgregation.mergeAggregatedReports(Seq(beforebaseReport,baseReport), Seq(reportToAdd))
+    val (toSave,toDelete) = aggregation.mergeAggregatedReports(Seq(baseReport), Seq(reportToAdd))
+    val (toSave2,toDelete2) = aggregation.mergeAggregatedReports(Seq(beforebaseReport,baseReport), Seq(reportToAdd))
     println(toSave2)
 
     "save must have 3 elements to save " in {
@@ -139,7 +141,7 @@ class AggregationTest extends Specification {
   }
 
     "MergeOne" should {
-    val (toSave,toDelete,_) = dummyAgregation.mergeOneAggregatedReport(Seq(baseReport), reportToAdd)
+    val (toSave,toDelete,_) = aggregation.mergeOneAggregatedReport(Seq(baseReport), reportToAdd)
 
     "have 3 elements to save " in {
 

--- a/rudder-core/src/test/scala/com/normation/rudder/reports/aggregation/AggregationTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/reports/aggregation/AggregationTest.scala
@@ -7,7 +7,7 @@ import com.normation.rudder.domain.reports.bean.Reports
 import com.normation.rudder.domain.policies._
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.reports.bean.ResultSuccessReport
-import org.joda.time.DateTime
+import org.joda.time.{ DateTime, Interval }
 import com.normation.rudder.domain.reports.bean.SuccessReportType
 import java.sql.Timestamp
 
@@ -22,109 +22,76 @@ class AggregationTest extends Specification {
   private implicit def str2DirectiveId(s:String) = DirectiveId(s)
   private implicit def str2RuleId(s:String) = RuleId(s)
   private implicit def str2nodeId(s:String) = NodeId(s)
+  private implicit def tuple2ToInterval(t2: Tuple2[DateTime, DateTime]) : Interval = new Interval(t2._1, t2._2)
 
   val now = DateTime.now()
 
   val report: Reports  = ResultSuccessReport(now, "cr", "policy", "one", 12, "component", "value",now, "message")
-
+  val key = ReportKey(report)
+  val msg = ""
+  val serials = SerialInterval(12,12)
+  
   val expectedReport = LinearisedExpectedReport(
-    NodeId("one")       : NodeId
-  , DirectiveId("policy")  : DirectiveId
-  , RuleId("cr")       : RuleId
-  , 12       : Int
-  , "component"    : String
-  , 1  : Int
-  , "value"     : String
-  , now minusMinutes(10)    : DateTime
-  , now plusMinutes(10)      : DateTime
-)
-  val reportToAdd : AggregatedReport = AggregatedReport(report,SuccessReportType,1,1)
+      key
+    , serial = 12 
+    , cardinality = 1  
+    , startDate = now minusMinutes(10)
+    , endDate = now plusMinutes(10)
+  )
+  
+  val reportToAdd : AggregatedReport = AggregatedReport(report, SuccessReportType, 1)
 
 
-    val baseReport : AggregatedReport = AggregatedReport (
-    NodeId("one")
-  , RuleId("cr")
-  , 12
-  , 12
-  , DirectiveId("policy")
-  , "component"
-  , "value"
-  , SuccessReportType
-  , ""
-  , now.minusMinutes(5)
-  , now.plusMinutes(5)
-  , 0
-  , 1
-  , 42
-)
+  val baseReport : AggregatedReport = AggregatedReport (
+      key
+    , 0
+    , SuccessReportType
+    , (now.minusMinutes(5), now.plusMinutes(5))
+    , msg
+    , serials
+    , Some(42)
+  )
+  
   val beforebaseReport : AggregatedReport = AggregatedReport (
-    NodeId("one")
-  , RuleId("cr")
-  , 12
-  , 12
-  , DirectiveId("policy")
-  , "component"
-  , "value"
-  , SuccessReportType
-  , ""
-  , now.minusMinutes(15)
-  , now.minusMinutes(5)
-  , 1
-  , 1
-  , 41
-)
+      key
+    , 1
+    , SuccessReportType
+    , (now.minusMinutes(15), now.minusMinutes(5))
+    , msg
+    , serials
+    , Some(41)
+  )
 
   val beginning2 : AggregatedReport = AggregatedReport (
-    NodeId("one")
-  , RuleId("cr")
-  , 12
-  , 12
-  , DirectiveId("policy")
-  , "component"
-  , "value"
-  , SuccessReportType
-  , ""
-  , now.minusMinutes(15)
-  , now
-  , 1
-  , 1
-  , 41
-)
+      key
+    , 1
+    , SuccessReportType
+    , (now.minusMinutes(15), now)
+    , msg
+    , serials
+    , Some(41)
+  )
 
   val begining : AggregatedReport = AggregatedReport (
-    NodeId("one")
-  , RuleId("cr")
-  , 12
-  , 12
-  , DirectiveId("policy")
-  , "component"
-  , "value"
-  , SuccessReportType
-  , ""
-  , now.minusMinutes(5)
-  , now
-  , 0
-  , 1
-  , 42
-)
+      key
+    , 0
+    , SuccessReportType
+    , (now.minusMinutes(5), now)
+    , msg
+    , serials
+    , Some(42)
+  )
 
   val dummyAgregation = new AggregationService(null, null, null, null, null,0,0)
 
   val ending : AggregatedReport = AggregatedReport (
-    NodeId("one")
-  , RuleId("cr")
-  , 12
-  , 12
-  , DirectiveId("policy")
-  , "component"
-  , "value"
-  , SuccessReportType
-  , ""
-  , now
-  , now.plusMinutes(5)
-  , 0
-  , 1
-  , 0
+      key
+    , 0
+    , SuccessReportType
+    , (now, now.plusMinutes(5))
+    , msg
+    , serials
+    , None
  )
 
 

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1392,9 +1392,10 @@ object RudderConfig extends Loggable {
     new AggregationService(
       expectedReportRepository
     , reportsRepository
-    , reportingService
     , aggregatedReportsJdbcRepository
     , updatesEntryJdbcRepository
+    , new SplitMergeAggregatedReport
+    , new InitializeAggregatedReport
     , delay
     , max
   )


### PR DESCRIPTION
I spent some time reviewing the propose code and cleaned some little things along the way. 

Doing the review, I was lost several time about why or when should or should not be merged, or extended, or updated. The logic is complexe, so I looked for a way to simplify it. 

I believe I found one by normalizing all interval endpoints on a reference set of edge. The reference set will be given by the execution timestamp of the agen for the node (now that we are going to store them), plus execution timestamp of new reports. 
Logic of the full algorithme is explained in file UnitAggregationService. It is implemented, but not tested at all, and misses lots of sanitization (what happen if we have no execution timesptamps, but aggregated reports? And other niceties), but I wanted to have actual code to discuss the thing. 
