### PR TITLE
Issue #8924: comments, tests, renomaing and moving things around

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -37,17 +37,17 @@
 
 package com.normation.rudder.domain.nodes
 
+import com.normation.inventory.domain.FullInventory
+
 import com.normation.inventory.domain.NodeId
-import com.normation.utils.HashcodeCaching
-import com.normation.rudder.reports.ReportingConfiguration
-import net.liftweb.json.JsonAST.JObject
-import org.joda.time.DateTime
+import com.normation.rudder.domain.policies.SimpleDiff
+import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.HeartbeatConfiguration
-import com.normation.rudder.domain.policies.SimpleDiff
-import com.normation.inventory.domain.FullInventory
-import com.normation.rudder.policyMode.PolicyMode
-import com.normation.rudder.policyMode.Enforce
+import com.normation.rudder.reports.ReportingConfiguration
+import com.normation.utils.HashcodeCaching
+
+import org.joda.time.DateTime
 
 /**
  * The entry point for a REGISTERED node in Rudder.
@@ -129,8 +129,8 @@ final case class ModifyNodePropertiesDiff(
  */
 object JsonSerialisation {
 
-  import net.liftweb.json.JsonDSL._
   import net.liftweb.json._
+  import net.liftweb.json.JsonDSL._
 
   implicit class JsonNodeProperty(x: NodeProperty) {
     def toLdapJson(): JObject = (
@@ -140,7 +140,6 @@ object JsonSerialisation {
   }
 
   implicit class JsonNodeProperties(props: Seq[NodeProperty]) {
-    import net.liftweb.json.Serialization.write
     implicit val formats = DefaultFormats
 
     private[this] def json(x: NodeProperty): JObject = (

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
@@ -44,7 +44,7 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.utils.HashcodeCaching
 import com.normation.cfclerk.domain.SectionSpec
 import com.normation.cfclerk.domain.Technique
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 
 case class DirectiveId(value : String) extends HashcodeCaching
 

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -80,8 +80,7 @@ import net.liftweb.json._
 import JsonDSL._
 import com.normation.rudder.reports._
 import com.normation.inventory.ldap.core.InventoryMapper
-import com.normation.rudder.policyMode.PolicyMode
-import com.normation.rudder.policyMode.Enforce
+import com.normation.rudder.domain.policies.PolicyMode
 
 /**
  * Map objects from/to LDAPEntries

--- a/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -94,7 +94,7 @@ import scala.xml.XML
 import scala.xml.PrettyPrinter
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 
 case class XmlUnserializerImpl (
     rule        : RuleUnserialisation

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/policies/PolicyModeTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/policies/PolicyModeTest.scala
@@ -1,0 +1,89 @@
+/*
+*************************************************************************************
+* Copyright 2011 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.domain.policies
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner._
+import net.liftweb.common._
+import com.normation.rudder.domain.policies.PolicyMode.Enforce
+import com.normation.rudder.domain.policies.PolicyMode.Verify
+
+@RunWith(classOf[JUnitRunner])
+class PolicyModeTest extends Specification with Loggable {
+
+
+  "Chekin rules on policy mode" should {
+    "show that global policy mode wins when not overridable" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Enforce, PolicyModeOverrides.Unoverridable)
+        , Some(Verify), Some(Verify) :: Nil
+      ) must equalTo(Enforce)
+    }
+    "show that global policy mode wins when not overridable" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Enforce, PolicyModeOverrides.Unoverridable)
+        , Some(Enforce), Some(Verify) :: Nil
+      ) must equalTo(Enforce)
+    }
+    "and loose when overridable" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Enforce, PolicyModeOverrides.Always)
+        , Some(Enforce), Some(Verify) :: Nil
+      ) must equalTo(Verify)
+    }
+    "and loose when overridable" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Enforce, PolicyModeOverrides.Always)
+        , Some(Verify), Some(Enforce) :: Nil
+      ) must equalTo(Verify)
+    }
+    "EVEN if global is on verify" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Verify, PolicyModeOverrides.Always)
+        , Some(Enforce), Some(Enforce) :: Nil
+      ) must equalTo(Enforce)
+    }
+    "But is chosen if nothign else defined" in {
+      PolicyMode.computeMode(
+          GlobalPolicyMode(Enforce, PolicyModeOverrides.Always)
+        , None, None :: Nil
+      ) must equalTo(Enforce)
+    }
+  }
+}

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -19,7 +19,6 @@ import com.normation.inventory.domain.Debian
 import com.normation.inventory.domain.Linux
 import com.normation.inventory.domain.Version
 import com.normation.inventory.domain.UndefinedKey
-import com.normation.rudder.policyMode.Enforce
 
 @RunWith(classOf[JUnitRunner])
 class RuleTargetTest extends Specification with Loggable {

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -58,7 +58,7 @@ import com.normation.inventory.domain.VirtualMachineType
 import com.normation.rudder.domain.nodes.MachineInfo
 import com.normation.inventory.domain.MemorySize
 import com.normation.inventory.domain.MachineUuid
-import com.normation.rudder.policyMode.Enforce
+import com.normation.rudder.domain.policies.PolicyMode.Enforce
 
 /*
  * This file is a container for testing data that are a little boring to

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -55,7 +55,6 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.rule.category.RuleCategoryId
-import com.normation.rudder.policyMode.Enforce
 
 /**
  * Test how RuleVal and DirectiveVal are constructed, and if they

--- a/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
@@ -66,7 +66,10 @@ import scala.language.implicitConversions
 import ca.mrvisser.sealerate
 import com.normation.rudder.web.components.popup.ModificationValidationPopup.Disable
 import com.normation.rudder.domain.appconfig.FeatureSwitch
-import com.normation.rudder.policyMode._
+import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode._
+import com.normation.rudder.domain.policies.GlobalPolicyMode
+import com.normation.rudder.domain.policies.PolicyModeOverrides
 
 /**
  * A service that Read mutable (runtime) configuration properties
@@ -140,10 +143,10 @@ trait ReadConfigService {
    */
   def rudder_global_policy_mode(): Box[GlobalPolicyMode] = {
     for {
-        mode <- rudder_policy_mode_name
+        mode        <- rudder_policy_mode_name
         overridable <- rudder_policy_overridable
     } yield {
-      GlobalPolicyMode(mode,overridable)
+      GlobalPolicyMode(mode, if(overridable) PolicyModeOverrides.Always else PolicyModeOverrides.Unoverridable)
     }
   }
   def rudder_policy_mode_name(): Box[PolicyMode]
@@ -267,7 +270,7 @@ trait UpdateConfigService {
   def set_rudder_policy_mode(mode : GlobalPolicyMode, actor: EventActor, reason: Option[String]): Box[Unit] = {
     for {
       _ <- set_rudder_policy_mode_name(mode.mode, actor, reason)
-      u <- set_rudder_policy_overridable(mode.overridable, actor, reason)
+      u <- set_rudder_policy_overridable(if(mode.overridable == PolicyModeOverrides.Always) true else false, actor, reason)
     } yield {
       u
     }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
@@ -73,8 +73,8 @@ import com.normation.rudder.services.queries.StringCriterionLine
 import com.normation.rudder.domain.queries.QueryReturnType
 import com.normation.rudder.domain.queries.NodeReturnType
 import com.normation.rudder.services.queries.StringQuery
-import com.normation.rudder.policyMode.PolicyMode
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 
 case class RestExtractorService (
     readRule             : RoRuleRepository

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/directive/DirectiveAPIService2.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/directive/DirectiveAPIService2.scala
@@ -73,7 +73,6 @@ import com.normation.rudder.web.rest.RestDataSerializer
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.services.TechniqueRepository
-import com.normation.rudder.policyMode.Enforce
 
 case class DirectiveAPIService2 (
     readDirective        : RoDirectiveRepository

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/directive/DirectiveApi.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/directive/DirectiveApi.scala
@@ -48,7 +48,7 @@ import com.normation.rudder.web.rest.RestAPI
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.cfclerk.domain.Technique
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 
 trait DirectiveAPI extends RestAPI {
   val kind = "directives"

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeApi.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeApi.scala
@@ -44,7 +44,7 @@ import net.liftweb.http.Req
 import net.liftweb.http.rest.RestHelper
 import com.normation.rudder.web.rest.RestAPI
 import com.normation.rudder.domain.nodes.NodeProperty
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 
 trait NodeAPI extends RestAPI {
   val kind = "nodes"

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/settings/SettingsApi.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/settings/SettingsApi.scala
@@ -53,7 +53,7 @@ import com.normation.eventlog.EventActor
 import net.liftweb.common.Full
 import net.liftweb.common.Failure
 import net.liftweb.json.JsonAST.JString
-import com.normation.rudder.policyMode.PolicyMode
+import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.json.JsonAST.JBool
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -67,7 +67,6 @@ import com.normation.rudder.authorization.NoRights
 import org.joda.time.DateTime
 import net.liftweb.http.js.JE.JsArray
 import com.normation.rudder.web.model.JsInitContextLinkUtil
-import com.normation.rudder.policyMode.Enforce
 
 /**
  * Snippet for managing the System and Active Technique libraries.


### PR DESCRIPTION
Some proposition to update the pr: 
- add some comments and tests, 
- refactore PolicyMode to have the GADT defined in object PolicyMode 
- remove PolicyModeService that was an object, so no added value compared to have its method defined in PolicyMode
- move PolicyMode in "policies" package, where it seems to belong