### PR TITLE
Make configuration-repository path a parameter of services

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/ResourceFileService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/ResourceFileService.scala
@@ -62,12 +62,10 @@ class GitResourceFileService(gitReposProvider: GitRepositoryProvider) extends Re
 
   def getResourcesFromDir(resourcesPath: String, techniqueName: String, techniqueVersion: String) = {
 
-    val resourceDir = File(s"/var/rudder/configuration-repository/${resourcesPath}")
-
     def getAllFiles(file: File): List[String] = {
       if (file.exists) {
         if (file.isRegularFile) {
-          resourceDir.relativize(file).toString :: Nil
+          (gitReposProvider.rootDirectory / resourcesPath).relativize(file).toString :: Nil
         } else {
           file.children.toList.flatMap(getAllFiles)
         }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -70,7 +70,8 @@ import zio.syntax._
 
 class SharedFilesAPI(
     restExtractor:    RestExtractorService,
-    sharedFolderPath: String
+    sharedFolderPath: String,
+    configRepoPath:   String
 ) extends RestHelper with Loggable {
 
   def checkPathAndContinue(path: String, baseFolder: File)(fun: File => IOResult[LiftResponse]): IOResult[LiftResponse] = {
@@ -421,12 +422,12 @@ class SharedFilesAPI(
       def isDefinedAt(req: Req): Boolean                 = {
         req.path.partPath match {
           case "draft" :: techniqueId :: techniqueVersion :: _ =>
-            val path = File(s"/var/rudder/configuration-repository/workspace/${techniqueId}/${techniqueVersion}/resources")
+            val path = File(s"${configRepoPath}/workspace/${techniqueId}/${techniqueVersion}/resources")
             val pf   = requestDispatch(path)
             pf.isDefinedAt(req.withNewPath(req.path.drop(3)))
           case techniqueId :: techniqueVersion :: categories   =>
             val path = File(
-              s"/var/rudder/configuration-repository/techniques/${categories.mkString("/")}/${techniqueId}/${techniqueVersion}/resources"
+              s"${configRepoPath}/techniques/${categories.mkString("/")}/${techniqueId}/${techniqueVersion}/resources"
             )
             val pf   = requestDispatch(path)
             pf.isDefinedAt(req.withNewPath(req.path.drop(req.path.partPath.size)))
@@ -437,13 +438,13 @@ class SharedFilesAPI(
       def apply(req: Req):       () => Box[LiftResponse] = {
         req.path.partPath match {
           case "draft" :: techniqueId :: techniqueVersion :: _ =>
-            val path = File(s"/var/rudder/configuration-repository/workspace/${techniqueId}/${techniqueVersion}/resources")
+            val path = File(s"${configRepoPath}/workspace/${techniqueId}/${techniqueVersion}/resources")
             path.createIfNotExists(true, true)
             val pf   = requestDispatch(path)
             pf.apply(req.withNewPath(req.path.drop(3)))
           case techniqueId :: techniqueVersion :: categories   =>
             val path = File(
-              s"/var/rudder/configuration-repository/techniques/${categories.mkString("/")}/${techniqueId}/${techniqueVersion}/resources"
+              s"${configRepoPath}/techniques/${categories.mkString("/")}/${techniqueId}/${techniqueVersion}/resources"
             )
             path.createIfNotExists(true, true)
             val pf   = requestDispatch(path)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -81,7 +81,8 @@ class TechniqueApi(
     techniqueRepository:  TechniqueRepository,
     techniqueSerializer:  TechniqueSerializer,
     uuidGen:              StringUuidGenerator,
-    resourceFileService:  ResourceFileService
+    resourceFileService:  ResourceFileService,
+    configRepoPath:       String
 ) extends LiftApiModuleProvider[API] {
 
   import techniqueSerializer._
@@ -349,8 +350,8 @@ class TechniqueApi(
       val workspacePath = s"workspace/${internalId}/${technique.version.value}/resources"
       val finalPath     = s"techniques/${technique.category}/${technique.id.value}/${technique.version.value}/resources"
 
-      val workspaceDir = File(s"/var/rudder/configuration-repository/${workspacePath}")
-      val finalDir     = File(s"/var/rudder/configuration-repository/${finalPath}")
+      val workspaceDir = File(s"${configRepoPath}/${workspacePath}")
+      val finalDir     = File(s"${configRepoPath}/${finalPath}")
 
       IOResult.attempt("Error when moving resource file from workspace to final destination")(if (workspaceDir.exists) {
         finalDir.createDirectoryIfNotExists(true)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -904,7 +904,8 @@ class RestTestSetUp {
       techniqueRepository,
       techniqueSerializer,
       uuidGen,
-      resourceFileService
+      resourceFileService,
+      mockGitRepo.configurationRepositoryRoot.pathAsString
     ),
     new DirectiveApi(
       mockDirectives.directiveRepo,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2075,7 +2075,8 @@ object RudderConfigInit {
           techniqueRepository,
           techniqueSerializer,
           stringUuidGenerator,
-          resourceFileService
+          resourceFileService,
+          RUDDER_GIT_ROOT_CONFIG_REPO
         ),
         new RuleApi(
           restExtractorService,
@@ -2114,7 +2115,7 @@ object RudderConfigInit {
     }
 
     // Internal APIs
-    lazy val sharedFileApi     = new SharedFilesAPI(restExtractorService, RUDDER_DIR_SHARED_FILES_FOLDER)
+    lazy val sharedFileApi     = new SharedFilesAPI(restExtractorService, RUDDER_DIR_SHARED_FILES_FOLDER, RUDDER_GIT_ROOT_CONFIG_REPO)
     lazy val eventLogApi       = new EventLogAPI(eventLogRepository, restExtractorService, eventLogDetailsGenerator, personIdentService)
     lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
     lazy val configService: ReadConfigService with UpdateConfigService = {


### PR DESCRIPTION
We must not use hardcoded path in services: 
- it's a redflag for security audit,
- it makes testing much harder