### PR TITLE
Correct behavior for migration

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -980,7 +980,7 @@ class ClassicTechniqueWriter(
 
       val reportingFile = File(
         basePath
-      ) / getTechniqueRelativePath(technique) / "rudder_reporting.cf"
+      ) / getTechniqueRelativePath(technique) / TechniqueFiles.Generated.cfengineReporting
       IOResult.attempt(
         s"Could not write na reporting Technique file '${technique.name}' in path ${reportingFile.path.toString}"
       ) {
@@ -1014,7 +1014,7 @@ class ClassicTechniqueWriter(
         {
       if (needReporting) {
         <FILE name={
-          s"RUDDER_CONFIGURATION_REPOSITORY/${getTechniqueRelativePath(technique)}/rudder_reporting.cf"
+          s"RUDDER_CONFIGURATION_REPOSITORY/${getTechniqueRelativePath(technique)}/${TechniqueFiles.Generated.cfengineReporting}"
         }>
             <INCLUDED>true</INCLUDED>
           </FILE>

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
@@ -1,1 +1,0 @@
-regenerated

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
@@ -1,0 +1,3 @@
+This should be removed: it existed in Rudder 7.3 when the webapp was generating content, but
+with rudderc in 8.0, it is not used anymore.
+It should also be cleanly committed.

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
@@ -114,7 +114,7 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
               .replace("<DESCRIPTION></DESCRIPTION>", "<DESCRIPTION>regenerated</DESCRIPTION>")
           )
           // we can replace other
-          (TechniqueFiles.Generated.dsc ++ TechniqueFiles.Generated.cfengine).foreach(n =>
+          (TechniqueFiles.Generated.dsc ++ TechniqueFiles.Generated.cfengineRudderc).foreach(n =>
             (techniqueDir / n).write("regenerated")
           )
           RuddercResult.Ok("", "", "")


### PR DESCRIPTION
Main changes: 

- never delete a `technique.json` file wihtout a migration. Only stage it if the file was deleted by the migration for clean commit
- same logic of staging for `rudder_reporting.cf`
- adapt tests to reflect that. In particular, our mock `rudderc` test service does not write `rudder_reporting.cf` anymore